### PR TITLE
Added new option to pick error handling mode in client

### DIFF
--- a/examples/simple/usage.ts
+++ b/examples/simple/usage.ts
@@ -1,16 +1,19 @@
 import Client from "./bindings.ts";
 
 const client = Client.new({
-	endpoint: "http://localhost:8081/_robin",
+	endpoint: "http://localhost:8060",
 });
 
 await client.queries.ping();
 
-const { data: todos } = await client.queries.todosList();
-const { data: newTodo } = await client.mutations.todosCreate({
+const todos = await client.queries.todosList();
+const newTodo = await client.mutations.todosCreate({
 	title: "Buy milk",
 	completed: false,
 });
 
 console.log("todos -> ", todos);
 console.log("newTodo -> ", newTodo);
+
+// This should throw since the generated client is set to throw on errors
+await client.queries.fail();

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -54,6 +54,9 @@ type (
 
 		// Whether to use the union result type or not - when enabled, the result type will be a uniion of the Ok and Error types which would disallow access to any of the fields without checking the `ok` field first
 		UseUnionResult bool
+
+		// Whether to throw a ProcedureCallError when a procedure call fails for any reason (e.g. invalid payload, user-defined error, etc.) instead of returning an error result
+		ThrowOnError bool
 	}
 
 	MethodTemplateOpts struct {
@@ -72,6 +75,9 @@ type (
 
 		// Whether to use the union result type or not - when enabled, the result type will be a uniion of the Ok and Error types which would disallow access to any of the fields without checking the `ok` field first
 		UseUnionResult bool
+
+		// Whether to throw a ProcedureCallError when a procedure call fails for any reason (e.g. invalid payload, user-defined error, etc.) instead of returning an error result
+		ThrowOnError bool
 	}
 
 	GeneratedMethods struct {
@@ -110,6 +116,7 @@ func (g *generator) GenerateBindings(opts GenerateBindingsOpts) (string, error) 
 		MutationMethods: strings.Join(methods.Mutations, "\n"),
 		QueryMethods:    strings.Join(methods.Queries, "\n"),
 		UseUnionResult:  opts.UseUnionResult,
+		ThrowOnError:    opts.ThrowOnError,
 	}); err != nil {
 		return "", fmt.Errorf("failed to execute bindings template: %w", err)
 	}

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -64,6 +64,11 @@ type (
 		Name         string
 		Type         string
 		HasPayload   bool
+		ThrowOnError bool
+	}
+
+	GenerateMethodsOpts struct {
+		ThrowOnError bool
 	}
 
 	GenerateBindingsOpts struct {
@@ -104,7 +109,7 @@ func (g *generator) GenerateBindings(opts GenerateBindingsOpts) (string, error) 
 		return "", fmt.Errorf("failed to parse bindings template: %w", err)
 	}
 
-	methods, err := g.GenerateMethods()
+	methods, err := g.GenerateMethods(GenerateMethodsOpts{ThrowOnError: opts.ThrowOnError})
 	if err != nil {
 		return "", fmt.Errorf("failed to generate methods: %w", err)
 	}
@@ -124,7 +129,7 @@ func (g *generator) GenerateBindings(opts GenerateBindingsOpts) (string, error) 
 	return builder.String(), nil
 }
 
-func (g *generator) GenerateMethods() (*GeneratedMethods, error) {
+func (g *generator) GenerateMethods(opts GenerateMethodsOpts) (*GeneratedMethods, error) {
 	var mutations, queries []string
 
 	for _, procedure := range g.procedures {
@@ -133,8 +138,8 @@ func (g *generator) GenerateMethods() (*GeneratedMethods, error) {
    * @procedure {{ .OriginalName }}
    *
    * @returns Promise<ProcedureResult<CSchema, "query", {{ printf "%q" .OriginalName }}>>
-   * @throws {ProcedureCallError} if the procedure call fails
-   */
+   {{if .ThrowOnError}}* @throws {ProcedureCallError} if the procedure call fails
+   {{end}}*/
   async {{.Name}}({{ if .HasPayload }}payload: PayloadOf<CSchema, {{ printf "%q" .Type }}, {{ printf "%q" .OriginalName }}>, {{end}}opts?: CallOpts<CSchema, {{ printf "%q" .Type }}, {{ printf "%q" .OriginalName }}>): Promise<ProcedureResult<CSchema, {{ printf "%q" .Type }}, {{ printf "%q" .OriginalName }}>> {
     return await this.client.call({{ printf "%q" .Type }}, { ...opts, name: {{ printf "%q" .OriginalName }}, payload: {{ if .HasPayload }}payload{{else}}undefined{{end}} });
   }`
@@ -154,6 +159,7 @@ func (g *generator) GenerateMethods() (*GeneratedMethods, error) {
 			Name:         NormalizeProcedureName(procedure.Name()),
 			Type:         procedureType,
 			HasPayload:   reflect.TypeOf(procedure.PayloadInterface()).Name() != "_RobinVoid",
+			ThrowOnError: opts.ThrowOnError,
 		}
 
 		method, err := template.New("method").Parse(methodTemplate)

--- a/generator/templates/client.template
+++ b/generator/templates/client.template
@@ -43,13 +43,13 @@ export type ResultOf<CSchema extends ClientSchema, PType extends ProcedureType, 
   PType
 >[PName]["result"];
 
-export type ProcedureResult<CSchema extends ClientSchema, PType extends ProcedureType, PName extends keyof SchemaBasedOnType<CSchema, PType>> = {{if .UseUnionResult}}
+export type ProcedureResult<CSchema extends ClientSchema, PType extends ProcedureType, PName extends keyof SchemaBasedOnType<CSchema, PType>> = {{if .ThrowOnError}}ResultOf<CSchema, PType, PName>{{else}}{{if .UseUnionResult}}
   | { ok: false; error: unknown; }
   | { ok: true; data: ResultOf<CSchema, PType, PName> };{{else}}{
   ok: boolean;
   data?: ResultOf<CSchema, PType, PName>;
   error?: unknown;
-}{{end}}
+}{{end}}{{end}}
 
 export type RawCallOpts<CSchema extends ClientSchema, PType extends ProcedureType, PName extends keyof SchemaBasedOnType<CSchema, PType>> = {
   name: PName;
@@ -128,8 +128,8 @@ class Client<CSchema extends ClientSchema{{if .IncludeSchema}} = Schema{{end}}> 
    * @returns Promise<ProcedureResult<CSchema, PType, PName>>
    *
    * @description Manually call a robin procedure; this is a low-level function that should not be used directly unless absolutely necessary
-   * @throws {ProcedureCallError} if the procedure call fails
-   */
+   {{if .ThrowOnError}}* @throws {ProcedureCallError} if the procedure call fails
+   {{end}}*/
   async call<PType extends ProcedureType, PName extends keyof SchemaBasedOnType<CSchema, PType>>(
     type: PType,
     opts: RawCallOpts<CSchema, PType, PName>
@@ -147,40 +147,35 @@ class Client<CSchema extends ClientSchema{{if .IncludeSchema}} = Schema{{end}}> 
       };
 
       const response = await this.clientFn(url, requestOpts);
+
       if (!response.ok) {
-        // If the response has a JSON body, try to parse it and get the error message since it is likely a robin error
+        let err: unknown = `Failed to call procedure \`${String(opts.name)}\` with status code ${response.status}`;
+
+        // Attempt to parse the response body as JSON to extract the error message
         try {
           const data = (await response.json()) as ServerResponse<ResultOf<CSchema, PType, PName>>;
-
-          if(!data) {
-            // Proceed to the unhappy throw path
-            throw new Error("No data returned from server");
+          if(!!data && data?.error) {
+            err = data?.error;
           }
-
-          // `ok` will most definitely be false here, but we still check it here as a guard if using the Union result type
-          if(!data.ok) {
-            return { ok: false, error: data?.error };
-          }
-        } catch (e) {
-          // Ignore any errors here
+        } catch(_e: unknown) {
+          /* Ignore errors here and just throw anyway */
         }
-
-        throw new ProcedureCallError(`Failed to call procedure \`${String(opts.name)}\` with status code ${response.status}`, String(opts.name));
+        {{if .ThrowOnError}}throw new ProcedureCallError(err, String(opts.name));{{else}}return { ok: false, error: err };{{end}}
       }
 
       const data = (await response.json()) as ServerResponse<ResultOf<CSchema, PType, PName>>;
       if (!data.ok) {
-        return { ok: false, error: data?.error || "An unknown error occurred" };
+        {{if .ThrowOnError}}throw new ProcedureCallError(data?.error || "An unknown error occurred", String(opts.name)); {{else}}return { ok: false, error: data?.error || "An unknown error occurred" }; {{end}}
       }
 
-      return { ok: true, data: data?.data as ResultOf<CSchema, PType, PName> };
-    } catch (e) {
-      if (e instanceof ProcedureCallError) {
+      {{if .ThrowOnError}}return data?.data as ResultOf<CSchema, PType, PName>;{{else}}return { ok: true, data: data?.data as ResultOf<CSchema, PType, PName> };{{end}}
+    } catch (e: unknown) {
+      {{if .ThrowOnError}}if (e instanceof ProcedureCallError) {
         throw e;
       }
 
-      const message = Object.prototype.hasOwnProperty.call(e, "message") ? (e as any).message : "An unknown error occurred";
-      throw new ProcedureCallError(message, String(opts.name), e as Error);
+      const message = Object.prototype.hasOwnProperty.call(e, "message") ? (e as {message: unknown}).message : "An unknown error occurred";
+      throw new ProcedureCallError(message, String(opts.name), e as Error);{{else}}return { ok: false, error: e };{{end}}
     }
   }
 
@@ -191,8 +186,8 @@ class Client<CSchema extends ClientSchema{{if .IncludeSchema}} = Schema{{end}}> 
    * @returns Promise<ProcedureResult<CSchema, "query", PName>>
    *
    * @description Manually call a robin query procedure
-   * @throws {ProcedureCallError} if the procedure call fails
-   */
+   {{if .ThrowOnError}}* @throws {ProcedureCallError} if the procedure call fails
+   {{end}}*/
   async query<PName extends keyof SchemaBasedOnType<CSchema, "query">>(
     name: PName,
     payload: PayloadOf<CSchema, "query", PName>,
@@ -209,8 +204,8 @@ class Client<CSchema extends ClientSchema{{if .IncludeSchema}} = Schema{{end}}> 
    * @returns Promise<ProcedureResult<CSchema, "mutation", PName>>
    *
    * @description Manually call a robin mutation procedure
-   * @throws {ProcedureCallError} if the procedure call fails
-   */
+   {{if .ThrowOnError}}* @throws {ProcedureCallError} if the procedure call fails
+   {{end}}*/
   async mutate<PName extends keyof SchemaBasedOnType<CSchema, "mutation">>(
     name: PName,
     payload: PayloadOf<CSchema, "mutation", PName>,
@@ -237,7 +232,7 @@ export class ProcedureCallError extends Error {
   // The previous error that caused this error, if any
   public previousError: Error | null;
 
-  public constructor(message: any, procedureName: string, originalError: Error | null = null) {
+  public constructor(message: unknown, procedureName: string, originalError: Error | null = null) {
     super(typeof message === "string" ? message : "A procedure call error occurred, see the `details` property for more information");
     this.name = "ProcedureCallError";
     this.details = message;

--- a/instance.go
+++ b/instance.go
@@ -160,6 +160,7 @@ func (i *Instance) Export(optPath ...string) error {
 			IncludeSchema:  !i.codegenOptions.GenerateSchema,
 			Schema:         schemaString,
 			UseUnionResult: i.codegenOptions.UseUnionResult,
+			ThrowOnError:   i.codegenOptions.ThrowOnError,
 		})
 		if err != nil {
 			return err

--- a/robin.go
+++ b/robin.go
@@ -60,6 +60,9 @@ type (
 
 		// Whether to use the union result type or not - when enabled, the result type will be a uniion of the Ok and Error types which would disallow access to any of the fields without checking the `ok` field first
 		UseUnionResult bool
+
+		// Whether to throw a ProcedureCallError when a procedure call fails for any reason (e.g. invalid payload, user-defined error, etc.) instead of returning an error result
+		ThrowOnError bool
 	}
 
 	Options struct {
@@ -298,5 +301,6 @@ func (r *Robin) extractCodegenOptions(opts *Options) (CodegenOptions, error) {
 		GenerateBindings: enableBindingsGen,
 		GenerateSchema:   enableSchemaGen,
 		UseUnionResult:   opts.CodegenOptions.UseUnionResult,
+		ThrowOnError:     opts.CodegenOptions.ThrowOnError,
 	}, nil
 }


### PR DESCRIPTION
Users can now decide if the client should throw or simply return a result type on failure.

- **Added new `ThrowOnError` option**
- **Updated generator to support new ThrowOnError option**
- **Throw on error in simple example**
- **Updated readme**
