### PR TITLE
Added support for reading raw payloads (#61)

### DIFF
--- a/base_types.go
+++ b/base_types.go
@@ -65,6 +65,9 @@ func (b *baseProcedure[_, _]) ExpectedPayloadType() types.ExpectedPayloadType {
 	return b.expectedPayloadType
 }
 
+// INFO: If you are wondering "why are you not just passing in in.InferredType()?",
+// it is because interfaces are nil by default and lose all type information when passed around,
+// so, the only way to keep the type information is to pass in the actual type from the function signature
 func implementsReadCloser[Out, In any](fn ProcedureFn[Out, In]) bool {
 	fnType := reflect.TypeOf(fn)
 	if fnType.NumIn() != 2 {

--- a/base_types.go
+++ b/base_types.go
@@ -1,0 +1,62 @@
+package robin
+
+import (
+	"go.trulyao.dev/robin/types"
+)
+
+type ProcedureFn[Out any, In any] func(ctx *Context, body In) (Out, error)
+
+type baseProcedure[Out any, In any] struct {
+	// The name of the procedure
+	name string
+
+	// The function that will be called when the procedure is executed
+	fn ProcedureFn[Out, In]
+
+	// A placeholder for the type of the body that the procedure expects
+	// WARNING: This never really has a value, it's just used for "type inference/reflection" during runtime
+	in types.In[In]
+
+	// A placeholder for the return type of the procedure
+	// WARNING: This never really has a value, it's just used for "type inference/reflection" during runtime
+	out Out
+
+	// Middleware functions to be executed before the mutation is called
+	middlewareFns []types.Middleware
+
+	// Indicates whether the procedure expects a payload, and if so, what type of payload it expects
+	expectedPayloadType types.ExpectedPayloadType
+
+	// Excluded middleware functions
+	excludedMiddleware *types.ExclusionList
+
+	// The procedure alias
+	alias string
+}
+
+func (b *baseProcedure[_, _]) Name() string {
+	return b.name
+}
+
+func (b *baseProcedure[_, _]) Alias() string {
+	return b.alias
+}
+
+// PayloadInterface returns a placeholder variable with the type of the payload that the procedure expects, this value is empty and only used for type inference/reflection during runtime
+func (b *baseProcedure[_, _]) PayloadInterface() any {
+	if b.expectedPayloadType == types.ExpectedPayloadRaw {
+		return b.in.OverrideType()
+	}
+
+	return b.in.InferredType()
+}
+
+// ReturnInterface returns a placeholder variable with the type of the return value of the procedure, this value is empty and only used for type inference/reflection during runtime
+func (b *baseProcedure[_, _]) ReturnInterface() any {
+	return b.out
+}
+
+// ExpectsPayload returns whether the procedure expects a payload or not
+func (b *baseProcedure[_, _]) ExpectedPayloadType() types.ExpectedPayloadType {
+	return b.expectedPayloadType
+}

--- a/examples/simple/bindings.ts
+++ b/examples/simple/bindings.ts
@@ -87,9 +87,9 @@ export type Schema = {
     "todos.list": {
       result: Array<{
         title: string;
-        task_description?: string;
+        task_description?: string | null;
         completed: boolean;
-        created_at?: string;
+        created_at?: string | null;
       }>;
       payload: void;
     };
@@ -98,15 +98,24 @@ export type Schema = {
     "todos.create": {
       result: {
         title: string;
-        task_description?: string;
+        task_description?: string | null;
         completed: boolean;
-        created_at?: string;
+        created_at?: string | null;
       };
       payload: {
         title: string;
-        task_description?: string;
+        task_description?: string | null;
         completed: boolean;
-        created_at?: string;
+        created_at?: string | null;
+      };
+    };
+    "raw": {
+      result: string;
+      payload: {
+        title: string;
+        task_description?: string | null;
+        completed: boolean;
+        created_at?: string | null;
       };
     };
   };
@@ -175,6 +184,16 @@ class Mutations<CSchema extends ClientSchema = Schema> {
    **/
   async todosCreate(payload: PayloadOf<CSchema, "mutation", "todos.create">, opts?: CallOpts<CSchema, "mutation", "todos.create">): Promise<ProcedureResult<CSchema, "mutation", "todos.create">> {
     return await this.client.call("mutation", { ...opts, name: "todos.create", payload: payload });
+  }
+
+  /**
+   * @procedure raw
+   *
+   * @returns Promise<ProcedureResult<CSchema, "query", "raw">>
+   * @throws {ProcedureCallError} if the procedure call fails
+   **/
+  async raw(payload: PayloadOf<CSchema, "mutation", "raw">, opts?: CallOpts<CSchema, "mutation", "raw">): Promise<ProcedureResult<CSchema, "mutation", "raw">> {
+    return await this.client.call("mutation", { ...opts, name: "raw", payload: payload });
   }
 }
 

--- a/examples/simple/usage.ts
+++ b/examples/simple/usage.ts
@@ -16,5 +16,18 @@ const newTodo = await client.mutations.todosCreate({
 console.log("todos -> ", todos);
 console.log("newTodo -> ", newTodo);
 
+const raw = await client.mutations.raw({
+	title: "Buy milk",
+	task_description: "Buy milk from the store",
+	completed: false,
+});
+const expected =
+	'{"d":{"title":"Buy milk","task_description":"Buy milk from the store","completed":false}}';
+if (raw !== expected) {
+	console.error("raw mutation failed");
+} else {
+	console.log("raw mutation succeeded");
+}
+
 // This should throw since the generated client is set to throw on errors
 // await client.queries.fail();

--- a/internal/guarded/check.go
+++ b/internal/guarded/check.go
@@ -2,9 +2,19 @@ package guarded
 
 import (
 	"reflect"
+
+	"go.trulyao.dev/robin/types"
 )
 
 // ExpectsPayload returns whether the given parameter expects a payload or not by checking if it is a void type
-func ExpectsPayload(param any) bool {
-	return reflect.TypeOf(param).Name() != "_RobinVoid"
+func ExpectsPayload(param any) types.ExpectedPayloadType {
+	if param == nil {
+		return types.ExpectedPayloadNone
+	}
+
+	if reflect.TypeOf(param).Name() != "_RobinVoid" {
+		return types.ExpectedPayloadDecoded
+	}
+
+	return types.ExpectedPayloadNone
 }

--- a/mutation.go
+++ b/mutation.go
@@ -82,6 +82,11 @@ func (m *mutation[_, _]) Type() ProcedureType {
 	return ProcedureTypeMutation
 }
 
+// String returns a string representation of the mutation
+func (m *mutation[_, _]) String() string {
+	return fmt.Sprintf("Mutation(%s)", m.name)
+}
+
 // PayloadInterface returns a placeholder variable with the type of the payload that the mutation expects, this value is empty and only used for type inference/reflection during runtime
 func (m *mutation[_, _]) PayloadInterface() any {
 	return m.in

--- a/mutation.go
+++ b/mutation.go
@@ -2,7 +2,6 @@ package robin
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"go.trulyao.dev/robin/internal/guarded"
@@ -143,6 +142,15 @@ func (m *mutation[_, _]) ExcludeMiddleware(names ...string) types.Procedure {
 // ExcludedMiddleware returns the list of middleware functions that are excluded from the query
 func (m *mutation[_, _]) ExcludedMiddleware() *types.ExclusionList {
 	return m.excludedMiddleware
+}
+
+func (m *mutation[_, _]) WithRawPayload(actualPayloadType any) Procedure {
+	// Ensure that the original input (provided via generics in In) is io.ReadCloser
+	mustImplementReadCloser(m.fn, ProcedureTypeMutation)
+
+	m.in.SetOverrideType(actualPayloadType)
+	m.expectedPayloadType = types.ExpectedPayloadRaw
+	return m
 }
 
 var _ Procedure = (*mutation[any, any])(nil)

--- a/mutation.go
+++ b/mutation.go
@@ -144,6 +144,21 @@ func (m *mutation[_, _]) ExcludedMiddleware() *types.ExclusionList {
 	return m.excludedMiddleware
 }
 
+// WARNING: This is an experimental feature and may be removed in the future in favour of a more robust solution and without notice
+//
+// This method will allow you to call a procedure with a raw payload, bypassing the payload decoding step.
+//
+// This means that you get the raw `[]byte` payload that was sent to the server, and you can do whatever you want with it.
+// This is extremely useful for cases where you, for instance, want to decode into a union that cannot be automatically handled by Robin.
+// It also still allows you to provide an accurate type to represent the payload that the procedure expects for type inference.
+//
+// Your procedure must have the following signature:
+//
+// func (ctx *Context, payload []byte) (YourReturnType, error)
+//
+// If not, this method will panic and force you to fix it.
+//
+// NOTE: The actual data is nested in the `d` key of the payload object (`{"d": "your data"}`)
 func (m *mutation[_, _]) WithRawPayload(actualPayloadType any) Procedure {
 	// Ensure that the original input (provided via generics in In) is io.ReadCloser
 	mustImplementReadCloser(m.fn, ProcedureTypeMutation)

--- a/procedures.go
+++ b/procedures.go
@@ -1,6 +1,10 @@
 package robin
 
-import "go.trulyao.dev/robin/types"
+import (
+	"slices"
+
+	"go.trulyao.dev/robin/types"
+)
 
 type (
 	Procedures []Procedure
@@ -49,7 +53,7 @@ func (p *Procedures) Add(procedure Procedure) {
 func (p *Procedures) Remove(name string, procedureType types.ProcedureType) {
 	for i, procedure := range *p {
 		if procedure.Name() == name && procedure.Type() == procedureType {
-			*p = append((*p)[:i], (*p)[i+1:]...)
+			*p = slices.Delete((*p), i, i+1)
 			break
 		}
 	}

--- a/query.go
+++ b/query.go
@@ -149,7 +149,21 @@ func (q *query[_, _]) ExcludedMiddleware() *types.ExclusionList {
 	return q.excludedMiddleware
 }
 
-// WithRawPayload sets the type of the payload that the query expects (for client type inference)
+// WARNING: This is an experimental feature and may be removed in the future in favour of a more robust solution and without notice
+//
+// This method will allow you to call a procedure with a raw payload, bypassing the payload decoding step.
+//
+// This means that you get the raw `[]byte` payload that was sent to the server, and you can do whatever you want with it.
+// This is extremely useful for cases where you, for instance, want to decode into a union that cannot be automatically handled by Robin.
+// It also still allows you to provide an accurate type to represent the payload that the procedure expects for type inference.
+//
+// Your procedure must have the following signature:
+//
+// func (ctx *Context, payload []byte) (YourReturnType, error)
+//
+// If not, this method will panic and force you to fix it.
+//
+// NOTE: The actual data is nested in the `d` key of the payload object (`{"d": "your data"}`)
 func (q *query[_, _]) WithRawPayload(actualPayloadType any) Procedure {
 	// Ensure that the original input (provided via generics in In) is io.ReadCloser
 	mustImplementReadCloser(q.fn, ProcedureTypeQuery)

--- a/query.go
+++ b/query.go
@@ -82,6 +82,11 @@ func (q *query[_, _]) Type() ProcedureType {
 	return ProcedureTypeQuery
 }
 
+// String returns a string representation of the query
+func (q *query[_, _]) String() string {
+	return fmt.Sprintf("Query(%s)", q.name)
+}
+
 // PayloadInterface returns a placeholder variable with the type of the payload that the query expects, this value is empty and only used for type inference/reflection during runtime
 func (q *query[_, _]) PayloadInterface() any {
 	return q.in

--- a/query.go
+++ b/query.go
@@ -2,7 +2,6 @@ package robin
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"go.trulyao.dev/robin/internal/guarded"
@@ -148,6 +147,16 @@ func (q *query[_, _]) ExcludeMiddleware(names ...string) types.Procedure {
 // ExcludedMiddleware returns the list of middleware functions that are excluded from the query
 func (q *query[_, _]) ExcludedMiddleware() *types.ExclusionList {
 	return q.excludedMiddleware
+}
+
+// WithRawPayload sets the type of the payload that the query expects (for client type inference)
+func (q *query[_, _]) WithRawPayload(actualPayloadType any) Procedure {
+	// Ensure that the original input (provided via generics in In) is io.ReadCloser
+	mustImplementReadCloser(q.fn, ProcedureTypeQuery)
+
+	q.in.SetOverrideType(actualPayloadType)
+	q.expectedPayloadType = types.ExpectedPayloadRaw
+	return q
 }
 
 var _ Procedure = (*query[any, any])(nil)

--- a/query_test.go
+++ b/query_test.go
@@ -1,9 +1,12 @@
 package robin_test
 
 import (
+	"io"
+	"reflect"
 	"testing"
 
 	"go.trulyao.dev/robin"
+	"go.trulyao.dev/robin/types"
 )
 
 func Test_QueryAlias(t *testing.T) {
@@ -19,7 +22,12 @@ func Test_QueryAlias(t *testing.T) {
 		{"NOT matching name with alias", "my_user", "lookup-user", "lookup-user"},
 		{"matching name with alias and dot", "get_user", "lookup.user", "lookup.user"},
 		{"NOT matching name with alias and dot", "my_user", "lookup.user", "lookup.user"},
-		{"matching name with multiple dots", "get_user", "lookup.user.profile", "lookup.user.profile"},
+		{
+			"matching name with multiple dots",
+			"get_user",
+			"lookup.user.profile",
+			"lookup.user.profile",
+		},
 		{"matching name with [lookup] prefix", "lookup_user", "", "user"},
 		{"matching name with [fetch] prefix", "fetch_user", "", "user"},
 		{"matching name with [get] prefix", "get_user", "", "user"},
@@ -40,5 +48,60 @@ func Test_QueryAlias(t *testing.T) {
 				t.Errorf("expected %s, got %s", test.expected, alias)
 			}
 		})
+	}
+}
+
+func Test_QueryWithRawPayloadPanic(t *testing.T) {
+	type User struct {
+		ID int `json:"id"`
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected a panic, but there was none")
+		}
+	}()
+
+	// This should panic
+	_ = robin.Q("get_user", func(ctx *robin.Context, body string) (string, error) {
+		return "", nil
+	}).WithRawPayload(User{})
+}
+
+func Test_MutationWithRawPayloadPanic(t *testing.T) {
+	type User struct {
+		ID int `json:"id"`
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected a panic, but there was none")
+		}
+	}()
+
+	// This should panic
+	_ = robin.M("get_user", func(ctx *robin.Context, body string) (string, error) {
+		return "", nil
+	}).WithRawPayload(User{})
+}
+
+func Test_WithRawPayload(t *testing.T) {
+	type User struct {
+		ID int `json:"id"`
+	}
+
+	q := robin.Q("get_user", func(ctx *robin.Context, body io.ReadCloser) (string, error) {
+		return "", nil
+	}).WithRawPayload(User{})
+
+	// Ensure we get the valid payload type
+	if q.ExpectedPayloadType() != types.ExpectedPayloadRaw {
+		t.Errorf("expected %v, got %v", types.ExpectedPayloadRaw, q.ExpectedPayloadType())
+	}
+
+	// Ensure the overriden payload type is correct
+	userType := reflect.TypeOf(User{})
+	if payload := q.PayloadInterface(); reflect.TypeOf(payload).String() != userType.String() {
+		t.Errorf("expected %v, got %v", userType, reflect.TypeOf(payload))
 	}
 }

--- a/robin.go
+++ b/robin.go
@@ -52,10 +52,14 @@ var (
 	ReIllegalDot = regexp.MustCompile(`\.{2,}`)
 
 	// Valid/common words associated with queries
-	ReQueryWords = regexp.MustCompile(`(?i)(^(get|fetch|list|lookup|search|find|query|retrieve|show|view|read)\.)`)
+	ReQueryWords = regexp.MustCompile(
+		`(?i)(^(get|fetch|list|lookup|search|find|query|retrieve|show|view|read)\.)`,
+	)
 
 	// Valid/common words associated with mutations
-	ReMutationWords = regexp.MustCompile(`(?i)(^(create|add|insert|update|upsert|edit|modify|change|delete|remove|destroy)\.)`)
+	ReMutationWords = regexp.MustCompile(
+		`(?i)(^(create|add|insert|update|upsert|edit|modify|change|delete|remove|destroy)\.)`,
+	)
 )
 
 type (
@@ -178,7 +182,10 @@ func (r *Robin) AddProcedure(procedure Procedure) *Robin {
 //
 // NOTE: Use `procedure.ExcludeMiddleware(...)` to exclude a middleware from a specific procedure
 func (r *Robin) Use(name string, middleware Middleware) *Robin {
-	r.namedGlobalMiddleware = append(r.namedGlobalMiddleware, GlobalMiddleware{Name: name, Fn: middleware})
+	r.namedGlobalMiddleware = append(
+		r.namedGlobalMiddleware,
+		GlobalMiddleware{Name: name, Fn: middleware},
+	)
 	return r
 }
 
@@ -213,14 +220,23 @@ func (r *Robin) Build() (*Instance, error) {
 		procedure.PrependMiddleware(globalMiddleware...)
 
 		if r.debug {
-			slog.Info("Global middleware added to procedure", slog.String("procedureName", procedure.Name()), slog.Int("middlewareCount", len(globalMiddleware)))
+			slog.Info(
+				"Global middleware added to procedure",
+				slog.String("procedureName", procedure.Name()),
+				slog.Int("middlewareCount", len(globalMiddleware)),
+			)
 		}
 
-		procedure.ExcludedMiddleware().Clear() // Clear the exclusion list to free up memory taken from the dedup
+		procedure.ExcludedMiddleware().
+			Clear()
+		// Clear the exclusion list to free up memory taken from the dedup
 	}
 
 	if r.debug {
-		slog.Info("Robin instance built successfully", slog.String("procedures", fmt.Sprintf("%v", r.procedures.Keys())))
+		slog.Info(
+			"Robin instance built successfully",
+			slog.String("procedures", fmt.Sprintf("%v", r.procedures.Keys())),
+		)
 	}
 
 	return &Instance{

--- a/types/procedure.go
+++ b/types/procedure.go
@@ -27,6 +27,32 @@ const (
 	HttpMethodDelete HttpMethod = "DELETE"
 )
 
+type ExpectedPayloadType int
+
+const (
+	ExpectedPayloadNone ExpectedPayloadType = iota
+	ExpectedPayloadDecoded
+	ExpectedPayloadRaw
+)
+
+type In[PayloadType any] struct {
+	inferredType PayloadType
+	overrideType any
+}
+
+func (i In[PayloadType]) InferredType() PayloadType {
+	return i.inferredType
+}
+
+func (i In[PayloadType]) OverrideType() any {
+	return i.overrideType
+}
+
+func (i In[PayloadType]) SetOverrideType(t any) any {
+	i.overrideType = t
+	return i.overrideType
+}
+
 type Procedure interface {
 	// The name of the procedure
 	Name() string
@@ -45,9 +71,10 @@ type Procedure interface {
 	// WARNING: whatever is returned here is only used for type inference/reflection during runtime; no value should be expected here
 	ReturnInterface() any
 
-	// Check if the procedure expects a payload or not
-	// This is useful for procedures that don't expect a payload, so we can instantly skip the payload decoding step
-	ExpectsPayload() bool
+	// Returns the type of the payload that the procedure expects
+	// This is useful for procedures that don't expect a payload, so we can instantly skip the payload decoding step.
+	// This is also useful for procedures that expect a raw payload, so we can skip the decoding step and pass the raw payload to the procedure.
+	ExpectedPayloadType() ExpectedPayloadType
 
 	// Call the procedure with the given context and payload
 	Call(*Context, any) (any, error)

--- a/types/procedure.go
+++ b/types/procedure.go
@@ -12,6 +12,10 @@ const (
 	ProcedureTypeMutation ProcedureType = "mutation"
 )
 
+func (p ProcedureType) String() string {
+	return string(p)
+}
+
 type JSONSerializable interface {
 	json.Marshaler
 	json.Unmarshaler
@@ -40,15 +44,15 @@ type In[PayloadType any] struct {
 	overrideType any
 }
 
-func (i In[PayloadType]) InferredType() PayloadType {
+func (i *In[PayloadType]) InferredType() PayloadType {
 	return i.inferredType
 }
 
-func (i In[PayloadType]) OverrideType() any {
+func (i *In[PayloadType]) OverrideType() any {
 	return i.overrideType
 }
 
-func (i In[PayloadType]) SetOverrideType(t any) any {
+func (i *In[PayloadType]) SetOverrideType(t any) any {
 	i.overrideType = t
 	return i.overrideType
 }
@@ -104,6 +108,21 @@ type Procedure interface {
 	//
 	// Common words like `get`, `find`, `create`, `update`, `delete` are normalized to their respective actions based on the procedure type
 	Alias() string
+
+	// WARNING: This is an experimental feature and may be removed in the future in favour of a more robust solution and without notice
+	//
+	// This method will allow you to call a procedure with a raw payload, bypassing the payload decoding step.
+	//
+	// This means that you get the raw `[]byte` payload that was sent to the server, and you can do whatever you want with it.
+	// This is extremely useful for cases where you, for instance, want to decode into a union that cannot be automatically handled by Robin.
+	// It also still allows you to provide an accurate type to represent the payload that the procedure expects for type inference.
+	//
+	// Your procedure must have the following signature:
+	//
+	// func (ctx *Context, payload []byte) (<your return type>, error)
+	//
+	// If not, this method will panic and force you to fix it.
+	WithRawPayload(actualPayloadType any) Procedure
 }
 
 // No-op type to represent a procedure that doesn't return any response or take any payload

--- a/types/procedure.go
+++ b/types/procedure.go
@@ -34,6 +34,9 @@ type Procedure interface {
 	// The type of the procedure, one of 'query' or 'mutation'
 	Type() ProcedureType
 
+	// Implement the Stringer interface
+	String() string
+
 	// Return an empty type that represents the payload that the procedure expects
 	// WARNING: whatever is returned here is only used for type inference/reflection during runtime; no value should be expected here
 	PayloadInterface() any

--- a/types/procedure.go
+++ b/types/procedure.go
@@ -119,7 +119,7 @@ type Procedure interface {
 	//
 	// Your procedure must have the following signature:
 	//
-	// func (ctx *Context, payload []byte) (<your return type>, error)
+	// func (ctx *Context, payload []byte) (YourReturnType, error)
 	//
 	// If not, this method will panic and force you to fix it.
 	WithRawPayload(actualPayloadType any) Procedure


### PR DESCRIPTION
- **Use slice.Delete instead of manual removal**
- **Add String() method for procedures**
- **Added new In and ExpectedPayloadType types**
- **Added shared procedure types for core structs**
- **Add new WithRawPayload modifier for procedures**
- **Handle different expected payload types**
- **Add tests, examples and docs for WithRawPayload modifier**
